### PR TITLE
Get layouttest out of the core markup and generate it dynamically.

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -270,11 +270,6 @@ Game = {
 &lt;em&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;Loading...&lt;/em&gt;
 &lt;/div&gt;
 &lt;div id="errorpane" style="display:none;"&gt;&lt;div id="errorcontent"&gt;...&lt;/div&gt;&lt;/div&gt;
-&lt;div id="layouttestpane"&gt;
-This should not be visible
-&lt;div id="layouttest_grid" class="WindowFrame GridWindow"&gt;&lt;div id="layouttest_gridline" class="GridLine"&gt;&lt;span id="layouttest_gridspan" class="Style_normal"&gt;12345678&lt;/span&gt;&lt;/div&gt;&lt;div id="layouttest_gridline2" class="GridLine"&gt;&lt;span class="Style_normal"&gt;12345678&lt;/span&gt;&lt;/div&gt;&lt;/div&gt;
-&lt;div id="layouttest_buffer" class="WindowFrame BufferWindow"&gt;&lt;div id="layouttest_bufferline" class="BufferLine"&gt;&lt;span id="layouttest_bufferspan" class="Style_normal"&gt;12345678&lt;/span&gt;&lt;/div&gt;&lt;div id="layouttest_bufferline2" class="BufferLine"&gt;&lt;span class="Style_normal"&gt;12345678&lt;/span&gt;&lt;/div&gt;&lt;/div&gt;
-&lt;/div&gt;
 &lt;/div&gt;
 
 &lt;/body&gt;
@@ -392,10 +387,6 @@ The GlkOte library begins working when you call <code>GlkOte.init</code>. The si
 &lt;/div&gt;
 &lt;div id="errorpane" style="display:none;"&gt;
     &lt;div id="errorcontent"&gt;...&lt;/div&gt;&lt;/div&gt;
-&lt;div id="layouttestpane"&gt;
-This should not be visible
-    <em>[...unwieldy but critical test data here...]</em>
-&lt;/div&gt;
 &lt;/div&gt;
 </pre>
 <p>
@@ -1313,7 +1304,6 @@ To play with your CSS, you have to know the structure of GlkOte's document. Let'
      <em>...windows...</em>
   &lt;div id="loadingpane"&gt;
   &lt;div id="errorpane"&gt;
-  &lt;div id="layouttestpane"&gt;
 </pre>
 <p>
 
@@ -1336,13 +1326,7 @@ The <code>loadingpane</code> contains the spinny compass and the sign "Loading..
 The <code>errorpane</code> is a red-bordered panel which appears at the top of the <code>gameport</code> when a fatal error occurs. Until that happens, it is hidden, so it won't be bothering you either.
 <p>
 
-The <code>layouttestpane</code> is... a nuisance. To reliably allocate space for, say, a grid window which is three lines high or forty columns wide, GlkOte has to know how large such a window will be -- including CSS padding, borders, line spacing, scroll bars, and all the other widgetry with which text surrounds itself. The easiest way to do this is to put a small text window in the DOM and measure it. This is <code>layouttestpane</code>.
-<p>
-
-The <code>layouttestpane</code> can't be hidden (<code>display:none</code>), because that prevents the web browser from constructing it at all. Instead, it has the property <code>visibility:hidden</code>. As an additional safeguard, it is placed far offscreen (<code>left:-1000px</code>). You should never see it.
-<p>
-
-You should not modify the CSS positioning of <code>windowport</code>, <code>loadingpane</code>, <code>errorpane</code>, or <code>layouttestpane</code>. You may modify their appearance, if you want.
+You should not modify the CSS positioning of <code>windowport</code>, <code>loadingpane</code>, or <code>errorpane</code>. You may modify their appearance, if you want.
 <p>
 
 <h3><a name="csswindowport">The contents of the <code>windowport</code></a></h3>

--- a/glkote-demo2.css
+++ b/glkote-demo2.css
@@ -32,15 +32,6 @@
   top: 20%;
 }
 
-#layouttestpane {
-  position: absolute;
-  visibility: hidden;
-  top: 0px;
-  /* Move this way off the screen. Even though it's hidden, Firefox has
-     a nasty habit of showing the inactive scroll bar. */
-  left: -1000px;
-}
-
 .WindowFrame {
   /* This class provides the default background color of windows. You
      can change that, but don't touch the position or margin. */

--- a/glkote.css
+++ b/glkote.css
@@ -32,15 +32,6 @@
   top: 20%;
 }
 
-#layouttestpane {
-  position: absolute;
-  visibility: hidden;
-  top: 0px;
-  /* Move this way off the screen. Even though it's hidden, Firefox has
-     a nasty habit of showing the inactive scroll bar. */
-  left: -1000px;
-}
-
 .WindowFrame {
   /* This class provides the default background color of windows. You
      can change that, but don't touch the position or margin. */

--- a/glkote.js
+++ b/glkote.js
@@ -244,41 +244,68 @@ function glkote_init(iface) {
      different point sizes)
    - the amount of padding space around buffer and grid window content
 
-   This stuff is determined by measuring the dimensions of the (invisible,
-   offscreen) windows in the layouttestpane div.
+   This stuff is determined by measuring dimensions of some invisible,
+   offscreen windows.
 */
 function measure_window() {
   var metrics = {};
-  var el, linesize, winsize, line1size, line2size, spansize;
+  var linesize, winsize, line1size, line2size, spansize;
 
   /* We assume the gameport is the same size as the windowport, which
      is true on all browsers but IE7. Fortunately, on IE7 it's
      the windowport size that's wrong -- gameport is the size
      we're interested in. */
-  el = $('#'+gameport_id);
-  if (!el.length)
+  var gameport = $('#' + gameport_id);
+  if (!gameport.length)
     return 'Cannot find gameport element #'+gameport_id+' in this document.';
 
   /* Exclude padding and border. */
-  metrics.width  = el.width();
-  metrics.height = el.height();
+  metrics.width  = gameport.width();
+  metrics.height = gameport.height();
 
-  el = $('#layouttest_grid');
-  if (!el.length)
-    return 'Cannot find layouttest_grid element for window measurement.';
+  /* Create a dummy layout div containing a grid window and a buffer window,
+   * each with two lines of text. */
+  var layout_test_pane = $('<div>');
+  layout_test_pane.css({
+    /* display: none would make the pane not render at all, making it
+     * impossible to measure.  Instead, make it invisible and offscreen. */
+    position: 'absolute',
+    visibility: 'hidden',
+    left: '-1000px'
+  });
+  var line = $('<div>');
+  $('<span>', {'class': "Style_normal"}).text('12345678').appendTo(line);
+
+  var gridwin = $('<div>', {'class': "WindowFrame GridWindow"});
+  var gridline1 = line.clone().addClass('GridLine').appendTo(gridwin);
+  var gridline2 = line.clone().addClass('GridLine').appendTo(gridwin);
+  var gridspan = gridline1.children('span');
+  layout_test_pane.append(gridwin);
+
+  var bufwin = $('<div>', {'class': "WindowFrame BufferWindow"});
+  var bufline1 = line.clone().addClass('BufferLine').appendTo(bufwin);
+  var bufline2 = line.clone().addClass('BufferLine').appendTo(bufwin);
+  var bufspan = bufline1.children('span');
+  layout_test_pane.append(bufwin);
+
+  layout_test_pane.appendTo(gameport);
+  console.log(layout_test_pane);
+
+  var get_size = function(element) {
+    return {
+      width: element.outerWidth(),
+      height: element.outerHeight()
+    };
+  };
 
   /* Here we will include padding and border. */
-  winsize = { width:el.outerWidth(), height:el.outerHeight() };
-  el = $('#layouttest_gridspan');
-  spansize = { width:el.outerWidth(), height:el.outerHeight() };
-  el = $('#layouttest_gridline');
-  line1size = { width:el.outerWidth(), height:el.outerHeight() };
-  el = $('#layouttest_gridline2');
-  line2size = { width:el.outerWidth(), height:el.outerHeight() };
+  winsize = get_size(gridwin);
+  spansize = get_size(gridspan);
+  line1size = get_size(gridline1);
+  line2size = get_size(gridline2);
 
-  metrics.gridcharheight = ($('#layouttest_gridline2').position().top
-    - $('#layouttest_gridline').position().top);
-  metrics.gridcharwidth = ($('#layouttest_gridspan').width() / 8);
+  metrics.gridcharheight = gridline2.position().top - gridline1.position().top;
+  metrics.gridcharwidth = gridspan.width() / 8;
   /* Yes, we can wind up with a non-integer charwidth value. */
 
   /* Find the total margin around the character grid (out to the window's
@@ -287,27 +314,22 @@ function measure_window() {
   metrics.gridmarginx = winsize.width - spansize.width;
   metrics.gridmarginy = winsize.height - (line1size.height + line2size.height);
 
-  el = $('#layouttest_buffer');
-  if (!el.length)
-    return 'Cannot find layouttest_buffer element for window measurement.';
-
   /* Here we will include padding and border. */
-  winsize = { width:el.outerWidth(), height:el.outerHeight() };
-  el = $('#layouttest_bufferspan');
-  spansize = { width:el.outerWidth(), height:el.outerHeight() };
-  el = $('#layouttest_bufferline');
-  line1size = { width:el.outerWidth(), height:el.outerHeight() };
-  el = $('#layouttest_bufferline2');
-  line2size = { width:el.outerWidth(), height:el.outerHeight() };
+  winsize = get_size(bufwin);
+  spansize = get_size(bufspan);
+  line1size = get_size(bufline1);
+  line2size = get_size(bufline2);
 
-  metrics.buffercharheight = ($('#layouttest_bufferline2').position().top
-    - $('#layouttest_bufferline').position().top);
-  metrics.buffercharwidth = ($('#layouttest_bufferspan').width() / 8);
+  metrics.buffercharheight = bufline2.position().top - bufline1.position().top;
+  metrics.buffercharwidth = bufspan.width() / 8;
   /* Yes, we can wind up with a non-integer charwidth value. */
 
   /* Again, these values include both sides (left+right, top+bottom). */
   metrics.buffermarginx = winsize.width - spansize.width;
   metrics.buffermarginy = winsize.height - (line1size.height + line2size.height);
+
+  /* Now that we're done measuring, discard the pane */
+  layout_test_pane.remove();
 
   /* these values come from the game interface object */
   metrics.outspacingx = 0;

--- a/sample-demo.html
+++ b/sample-demo.html
@@ -100,11 +100,6 @@ Game = {
 <em>&nbsp;&nbsp;&nbsp;Loading...</em>
 </div>
 <div id="errorpane" style="display:none;"><div id="errorcontent">...</div></div>
-<div id="layouttestpane">
-This should not be visible
-<div id="layouttest_grid" class="WindowFrame GridWindow"><div id="layouttest_gridline" class="GridLine"><span id="layouttest_gridspan" class="Style_normal">12345678</span></div><div id="layouttest_gridline2" class="GridLine"><span class="Style_normal">12345678</span></div></div>
-<div id="layouttest_buffer" class="WindowFrame BufferWindow"><div id="layouttest_bufferline" class="BufferLine"><span id="layouttest_bufferspan" class="Style_normal">12345678</span></div><div id="layouttest_bufferline2" class="BufferLine"><span class="Style_normal">12345678</span></div></div>
-</div>
 </div>
 
 </body>

--- a/sample-demo2.html
+++ b/sample-demo2.html
@@ -120,11 +120,6 @@ Game = {
 <em>&nbsp;&nbsp;&nbsp;Loading...</em>
 </div>
 <div id="errorpane" style="display:none;"><div id="errorcontent">...</div></div>
-<div id="layouttestpane">
-This should not be visible
-<div id="layouttest_grid" class="WindowFrame GridWindow"><div id="layouttest_gridline" class="GridLine"><span id="layouttest_gridspan" class="Style_normal">12345678</span></div><div id="layouttest_gridline2" class="GridLine"><span class="Style_normal">12345678</span></div></div>
-<div id="layouttest_buffer" class="WindowFrame BufferWindow"><div id="layouttest_bufferline" class="BufferLine"><span id="layouttest_bufferspan" class="Style_normal">12345678</span></div><div id="layouttest_bufferline2" class="BufferLine"><span class="Style_normal">12345678</span></div></div>
-</div>
 </div>
 
 </div>

--- a/sample-demobase.html
+++ b/sample-demobase.html
@@ -212,11 +212,6 @@ Game = {
 <em>&nbsp;&nbsp;&nbsp;Loading...</em>
 </div>
 <div id="errorpane" style="display:none;"><div id="errorcontent">...</div></div>
-<div id="layouttestpane">
-This should not be visible
-<div id="layouttest_grid" class="WindowFrame GridWindow"><div id="layouttest_gridline" class="GridLine"><span id="layouttest_gridspan" class="Style_normal">12345678</span></div><div id="layouttest_gridline2" class="GridLine"><span class="Style_normal">12345678</span></div></div>
-<div id="layouttest_buffer" class="WindowFrame BufferWindow"><div id="layouttest_bufferline" class="BufferLine"><span id="layouttest_bufferspan" class="Style_normal">12345678</span></div><div id="layouttest_bufferline2" class="BufferLine"><span class="Style_normal">12345678</span></div></div>
-</div>
 </div>
 
 </body>

--- a/sample-minimal.html
+++ b/sample-minimal.html
@@ -55,11 +55,6 @@ Game = {
 <em>&nbsp;&nbsp;&nbsp;Loading...</em>
 </div>
 <div id="errorpane" style="display:none;"><div id="errorcontent">...</div></div>
-<div id="layouttestpane">
-This should not be visible
-<div id="layouttest_grid" class="WindowFrame GridWindow"><div id="layouttest_gridline" class="GridLine"><span id="layouttest_gridspan" class="Style_normal">12345678</span></div><div id="layouttest_gridline2" class="GridLine"><span class="Style_normal">12345678</span></div></div>
-<div id="layouttest_buffer" class="WindowFrame BufferWindow"><div id="layouttest_bufferline" class="BufferLine"><span id="layouttest_bufferspan" class="Style_normal">12345678</span></div><div id="layouttest_bufferline2" class="BufferLine"><span class="Style_normal">12345678</span></div></div>
-</div>
 </div>
 
 </body>


### PR DESCRIPTION
Greatly reduces the markup needed to actually use glkote, and makes it a little more resilient to a bad copy/paste job.

This doesn't really work without the corresponding quixe pull, which I'll be posting momentarily...