### PR TITLE
Keep keyboard up on iOS Safari when submitting commands

### DIFF
--- a/glkote.js
+++ b/glkote.js
@@ -826,18 +826,8 @@ function glkote_update(arg) {
     }
   }
 
-  if (newinputwin) {
-    /* MSIE is weird about when you can call focus(). The input element
-       has probably just been added to the DOM, and MSIE balks at
-       giving it the focus right away. So we defer the call until
-       after the javascript context has yielded control to the browser. */
-    var focusfunc = function() {
-      var win = windowdic.get(newinputwin);
-      if (win.inputel) {
-        win.inputel.focus();
-      }
-    };
-    defer_func(focusfunc);
+  if (newinputwin && windowdic[newinputwin].inputel) {
+    windowdic[newinputwin].inputel.focus();
   }
 
   if (autorestore) {


### PR DESCRIPTION
I made sure to test this behavior on old versions of IE. The existing master glkote `sample-demo.html` doesn't work in IE9 ("Object doesn't support property or method 'matchMedia'"); my PR works fine in IE10+ and Edge.

In addition to fixing an annoying usability bug, keeping the keyboard on screen is also a huge help for iOS Voiceover support. When keyboard focus is lost, Voiceover seems to randomly jump to the tab-selector button (the last control on the screen); keeping the keyboard up means VI users can just continue to type after typing their command (just like the rest of us)!

Fixes https://github.com/erkyrath/glkote/issues/48
