### PR TITLE
Support glkapi.js in node

### DIFF
--- a/electrofs.js
+++ b/electrofs.js
@@ -5,10 +5,10 @@
  * This Javascript library is copyright 2016 by Andrew Plotkin.
  * It is distributed under the MIT license; see the "LICENSE" file.
  *
- * This is a (mostly-) drop-in replacement for dialog.js for the Electron.io
- * environment. It uses the Node.js "fs" and "path" packages to read and write
- * files, and the Electron.io "dialog" package to present file-selection
- * dialogs.
+ * This is a (mostly-) drop-in replacement for dialog.js for node and the
+ * Electron.io environment. It uses the Node.js "fs" and "path" packages to
+ * read and write files, and the Electron.io "dialog" package to present
+ * file-selection dialogs.
  *
  * The interface is similar to dialog.js, but not exactly the same. (Sorry!
  * The Atom/Electron API didn't exist when I write dialog.js, or I would
@@ -19,21 +19,14 @@
  * dialog.js.
  */
 
-Dialog = function() {
+'use strict';
+
+var Dialog = function() {
 
 const fs = require('fs');
+const os = require('os');
 const path_mod = require('path');
 const buffer_mod = require('buffer');
-var userpath = require('electron').remote.app.getPath('userData');
-var extfilepath = path_mod.join(userpath, 'quixe-files');
-
-/* We try to create a directory for external files at launch time.
-   This will usually fail because there's already a directory there.
-*/
-try {
-    fs.mkdirSync(extfilepath);
-}
-catch (ex) {}
 
 /* Constants -- same as in glkapi.js. */
 const filemode_Write = 0x01;
@@ -50,162 +43,6 @@ const fileusage_InputRecord = 0x03;
 
 /* The size of our stream buffering. */
 const BUFFER_SIZE = 256;
-
-/* Construct a file-filter list for a given usage type. These lists are
-   used by showOpenDialog and showSaveDialog, below. 
-*/
-function filters_for_usage(val)
-{
-    switch (val) {
-    case 'data': 
-        return [ { name: 'Glk Data File', extensions: ['glkdata'] } ];
-    case 'save': 
-        return [ { name: 'Glk Save File', extensions: ['glksave'] } ];
-    case 'transcript': 
-        return [ { name: 'Transcript File', extensions: ['txt'] } ];
-    case 'command': 
-        return [ { name: 'Command File', extensions: ['txt'] } ];
-    default:
-        return [];
-    }
-}
-
-/* Dialog.open(tosave, usage, gameid, callback) -- open a file-choosing dialog
- *
- * The "tosave" flag should be true for a save dialog, false for a load
- * dialog.
- *
- * The "usage" and "gameid" arguments are arbitrary strings which describe the
- * file. These filter the list of files displayed; the dialog will only list
- * files that match the arguments. Pass null to either argument (or both) to
- * skip filtering.
- *
- * The "callback" should be a function. This will be called with a fileref
- * argument (see below) when the user selects a file. If the user cancels the
- * selection, the callback will be called with a null argument.
-*/
-function dialog_open(tosave, usage, gameid, callback)
-{
-    const dialog = require('electron').remote.dialog;
-    var opts = {
-        filters: filters_for_usage(usage)
-    };
-    var mainwin = require('electron').remote.getCurrentWindow();
-    if (!tosave) {
-        opts.properties = ['openFile'];
-        dialog.showOpenDialog(mainwin, opts, function(ls) {
-                if (!ls || !ls.length) {
-                    callback(null);
-                }
-                else {
-                    var ref = { filename:ls[0], usage:usage };
-                    callback(ref);
-                }
-            });
-    }
-    else {
-        dialog.showSaveDialog(mainwin, opts, function(path) {
-                if (!path) {
-                    callback(null);
-                }
-                else {
-                    var ref = { filename:path, usage:usage };
-                    callback(ref);
-                }
-            });
-    }
-}
-
-/* Dialog.file_clean_fixed_name(filename, usage) -- clean up a filename
- *
- * Take an arbitrary string and convert it into a filename that can
- * validly be stored in the user's directory. This is called for filenames
- * that come from the game file, but not for filenames selected directly
- * by the user (i.e. from a file selection dialog).
- *
- * The new spec recommendations: delete all characters in the string
- * "/\<>:|?*" (including quotes). Truncate at the first period. Change to
- * "null" if there's nothing left. Then append an appropriate suffix:
- * ".glkdata", ".glksave", ".txt".
- */
-function file_clean_fixed_name(filename, usage) {
-    var res = filename.replace(/["/\\<>:|?*]/g, '');
-    var pos = res.indexOf('.');
-    if (pos >= 0) 
-        res = res.slice(0, pos);
-    if (res.length == 0)
-        res = "null";
-
-    switch (usage) {
-    case fileusage_Data:
-        return res + '.glkdata';
-    case fileusage_SavedGame:
-        return res + '.glksave';
-    case fileusage_Transcript:
-    case fileusage_InputRecord:
-        return res + '.txt';
-    default:
-        return res;
-    }
-}
-
-/* Dialog.file_construct_ref(filename, usage, gameid) -- create a fileref
- *
- * Create a fileref. This does not create a file; it's just a thing you can use
- * to read an existing file or create a new one. Any unspecified arguments are
- * assumed to be the empty string.
- */
-function file_construct_ref(filename, usage, gameid)
-{
-    if (!filename)
-        filename = '';
-    if (!usage)
-        usage = '';
-    if (!gameid)
-        gameid = '';
-    var path = path_mod.join(extfilepath, filename);
-    var ref = { filename:path, usage:usage };
-    return ref;
-}
-
-/* Dialog.file_construct_temp_ref(usage)
- *
- * Create a fileref in a temporary directory. Every time this is called
- * it should create a completely new fileref.
- */
-function file_construct_temp_ref(usage)
-{
-    var timestamp = new Date().getTime();
-    var filename = "_temp_" + timestamp + "_" + Math.random();
-    filename = filename.replace('.', '');
-    var temppath = require('electron').remote.app.getPath('temp');
-    var path = path_mod.join(temppath, filename);
-    var ref = { filename:path, usage:usage };
-    return ref;
-}
-
-/* Dialog.file_ref_exists(ref) -- returns whether the file exists
- */
-function file_ref_exists(ref)
-{
-    try {
-        fs.accessSync(ref.filename, fs.F_OK);
-        return true;
-    }
-    catch (ex) {
-        return false;
-    }
-}
-
-/* Dialog.file_remove_ref(ref) -- delete the file, if it exists
- */
-function file_remove_ref(ref)
-{
-    try {
-        fs.unlinkSync(ref.filename);
-    }
-    catch (ex) { }
-}
 
 /* FStream -- constructor for a file stream. This is what file_fopen()
  * returns. It is analogous to a FILE* in C code.
@@ -238,7 +75,9 @@ FStream.prototype = {
      */
     fclose : function() {
         if (this.fd === null) {
-            GlkOte.log('file_fclose: file already closed: ' + this.filename);
+            if (typeof GlkOte !== 'undefined') {
+                GlkOte.log('file_fclose: file already closed: ' + this.filename);
+            }
             return;
         }
         /* flush any unwritten data */
@@ -396,212 +235,405 @@ FStream.prototype = {
 
 };
 
-/* Dialog.file_fopen(fmode, ref) -- open a file for reading or writing
- *
- * Returns an FStream object.
- */
-function file_fopen(fmode, ref)
-{
-    /* This object is analogous to a FILE* in C code. Yes, we're 
-       reimplementing fopen() for Node.js. I'm not proud. Or tired. 
-       The good news is, the logic winds up identical to that in
-       the C libraries.
-    */
-    var fstream = new FStream(fmode, ref.filename);
-
-    /* The spec says that Write, ReadWrite, and WriteAppend create the
-       file if necessary. However, open(filename, "r+") doesn't create
-       a file. So we have to pre-create it in the ReadWrite and
-       WriteAppend cases. (We use "a" so as not to truncate.) */
-
-    if (fmode == filemode_ReadWrite || fmode == filemode_WriteAppend) {
+/* A generic Node fs based dialog class */
+class Dialog {
+    constructor() {
+        this.streaming = true;
+        this.userpath = this.get_user_path();
+        this.extfilepath = path_mod.join(this.userpath, 'quixe-files');
+        
+        /* We try to create a directory for external files at launch time.
+           This will usually fail because there's already a directory there.
+        */
         try {
-            var tempfd = fs.openSync(fstream.filename, "a");
-            fs.closeSync(tempfd);
-        }
-        catch (ex) {
-            GlkOte.log('file_fopen: failed to open ' + fstream.filename + ': ' + ex);
-            return null;
-        }
-    }
-
-    /* Another Unix quirk: in r+ mode, you're not supposed to flip from
-       reading to writing or vice versa without doing an fseek. We will
-       track the most recent operation (as lastop) -- Write, Read, or
-       0 if either is legal next. */
-
-    var modestr = null;
-    switch (fmode) {
-        case filemode_Write:
-            modestr = "w";
-            break;
-        case filemode_Read:
-            modestr = "r";
-            break;
-        case filemode_ReadWrite:
-            modestr = "r+";
-            break;
-        case filemode_WriteAppend:
-            /* Can't use "a" here, because then fseek wouldn't work.
-               Instead we use "r+" and then fseek to the end. */
-            modestr = "r+";
-            break;
-    }
-
-    try {
-        fstream.fd = fs.openSync(fstream.filename, modestr);
-    }
-    catch (ex) {
-        GlkOte.log('file_fopen: failed to open ' + fstream.filename + ': ' + ex);
-        return null;
-    }
-
-    if (fmode == filemode_WriteAppend) {
-        /* We must jump to the end of the file. */
-        try {
-            var stats = fs.fstatSync(fstream.fd);
-            fstream.mark = stats.size;
+            fs.mkdirSync(this.extfilepath);
         }
         catch (ex) {}
     }
 
-    return fstream;
-}
+    /* Load a snapshot (a JSONable object) from a signature-dependent location.
+    */
+    autosave_read(signature)
+    {
+        var gamedirpath = path_mod.join(this.userpath, 'games', signature);
+        var pathj = path_mod.join(gamedirpath, 'autosave.json');
+        var pathr = path_mod.join(gamedirpath, 'autosave.ram');
 
-/* Store a snapshot (a JSONable object) in a signature-dependent location.
-   If snapshot is null, delete the snapshot instead.
-*/
-function autosave_write(signature, snapshot)
-{
-    var gamedirpath = path_mod.join(userpath, 'games', signature);
+        try {
+            var str = fs.readFileSync(pathj, { encoding:'utf8' });
+            var snapshot = JSON.parse(str);
 
-    /* Make sure the gamedirpath exists. */
-    var stat = null;
-    try {
-        stat = fs.statSync(gamedirpath);
+            try {
+                var buf = fs.readFileSync(pathr, { encoding:null });
+                var ram = Array.from(buf.values());
+                snapshot.ram = ram;
+            }
+            catch (ex) {};
+
+            return snapshot;
+        }
+        catch (ex) {
+            return null;
+        };
     }
-    catch (ex) {};
-    if (!stat || !stat.isDirectory()) {
-        try {
-            fs.mkdirSync(path_mod.join(userpath, 'games'));
-        }
-        catch (ex) {};
-        try {
-            fs.mkdirSync(gamedirpath);
-        }
-        catch (ex) {};
-        stat = null;
+
+    /* Store a snapshot (a JSONable object) in a signature-dependent location.
+       If snapshot is null, delete the snapshot instead.
+    */
+    autosave_write(signature, snapshot)
+    {
+        var gamedirpath = path_mod.join(this.userpath, 'games', signature);
+
+        /* Make sure the gamedirpath exists. */
+        var stat = null;
         try {
             stat = fs.statSync(gamedirpath);
         }
         catch (ex) {};
         if (!stat || !stat.isDirectory()) {
-            /* Can't create the directory; give up. */
-            GlkOte.log('Unable to create gamedirpath: ' + gamedirpath);
+            try {
+                fs.mkdirSync(path_mod.join(this.userpath, 'games'));
+            }
+            catch (ex) {};
+            try {
+                fs.mkdirSync(gamedirpath);
+            }
+            catch (ex) {};
+            stat = null;
+            try {
+                stat = fs.statSync(gamedirpath);
+            }
+            catch (ex) {};
+            if (!stat || !stat.isDirectory()) {
+                /* Can't create the directory; give up. */
+                this.log('Unable to create gamedirpath: ' + gamedirpath);
+                return;
+            }
+        }
+
+        /* We'll save the snapshot in two files: a .ram file (snapshot.ram
+           as raw bytes) and a .json file (the rest of snapshot, stringified).
+        */
+
+        var pathj = path_mod.join(gamedirpath, 'autosave.json');
+        var pathr = path_mod.join(gamedirpath, 'autosave.ram');
+
+        if (!snapshot) {
+            try {
+                fs.unlinkSync(pathj);
+            }
+            catch (ex) {};
+            try {
+                fs.unlinkSync(pathr);
+            }
+            catch (ex) {};
             return;
         }
+
+        /* Pull snapshot.ram out, if it exists. (It's okay to munge the
+           snapshot object,the caller doesn't want it back.) */
+        var ram = snapshot.ram;
+        snapshot.ram = undefined;
+
+        var str = JSON.stringify(snapshot);
+        fs.writeFileSync(pathj, str, { encoding:'utf8' });
+
+        if (ram) {
+            var buf = new buffer_mod.Buffer(ram);
+            fs.writeFileSync(pathr, buf);
+        }
     }
 
-    /* We'll save the snapshot in two files: a .ram file (snapshot.ram
-       as raw bytes) and a .json file (the rest of snapshot, stringified).
+    /* Dialog.file_clean_fixed_name(filename, usage) -- clean up a filename
+     *
+     * Take an arbitrary string and convert it into a filename that can
+     * validly be stored in the user's directory. This is called for filenames
+     * that come from the game file, but not for filenames selected directly
+     * by the user (i.e. from a file selection dialog).
+     *
+     * The new spec recommendations: delete all characters in the string
+     * "/\<>:|?*" (including quotes). Truncate at the first period. Change to
+     * "null" if there's nothing left. Then append an appropriate suffix:
+     * ".glkdata", ".glksave", ".txt".
+     */
+    file_clean_fixed_name(filename, usage) {
+        var res = filename.replace(/["/\\<>:|?*]/g, '');
+        var pos = res.indexOf('.');
+        if (pos >= 0) 
+            res = res.slice(0, pos);
+        if (res.length == 0)
+            res = "null";
+
+        switch (usage) {
+        case fileusage_Data:
+            return res + '.glkdata';
+        case fileusage_SavedGame:
+            return res + '.glksave';
+        case fileusage_Transcript:
+        case fileusage_InputRecord:
+            return res + '.txt';
+        default:
+            return res;
+        }
+    }
+
+    /* Dialog.file_construct_ref(filename, usage, gameid) -- create a fileref
+     *
+     * Create a fileref. This does not create a file; it's just a thing you can use
+     * to read an existing file or create a new one. Any unspecified arguments are
+     * assumed to be the empty string.
+     */
+    file_construct_ref(filename, usage, gameid)
+    {
+        if (!filename)
+            filename = '';
+        if (!usage)
+            usage = '';
+        if (!gameid)
+            gameid = '';
+        var path = path_mod.join(this.extfilepath, filename);
+        var ref = { filename:path, usage:usage };
+        return ref;
+    }
+
+    /* Dialog.file_construct_temp_ref(usage)
+     *
+     * Create a fileref in a temporary directory. Every time this is called
+     * it should create a completely new fileref.
+     */
+    file_construct_temp_ref(usage)
+    {
+        var timestamp = new Date().getTime();
+        var filename = "_temp_" + timestamp + "_" + Math.random();
+        filename = filename.replace('.', '');
+        var temppath = this.get_temp_path();
+        var path = path_mod.join(temppath, filename);
+        var ref = { filename:path, usage:usage };
+        return ref;
+    }
+
+    /* Dialog.file_fopen(fmode, ref) -- open a file for reading or writing
+     *
+     * Returns an FStream object.
+     */
+    file_fopen(fmode, ref)
+    {
+        /* This object is analogous to a FILE* in C code. Yes, we're 
+           reimplementing fopen() for Node.js. I'm not proud. Or tired. 
+           The good news is, the logic winds up identical to that in
+           the C libraries.
+        */
+        var fstream = new FStream(fmode, ref.filename);
+
+        /* The spec says that Write, ReadWrite, and WriteAppend create the
+           file if necessary. However, open(filename, "r+") doesn't create
+           a file. So we have to pre-create it in the ReadWrite and
+           WriteAppend cases. (We use "a" so as not to truncate.) */
+
+        if (fmode == filemode_ReadWrite || fmode == filemode_WriteAppend) {
+            try {
+                var tempfd = fs.openSync(fstream.filename, "a");
+                fs.closeSync(tempfd);
+            }
+            catch (ex) {
+                this.log('file_fopen: failed to open ' + fstream.filename + ': ' + ex);
+                return null;
+            }
+        }
+
+        /* Another Unix quirk: in r+ mode, you're not supposed to flip from
+           reading to writing or vice versa without doing an fseek. We will
+           track the most recent operation (as lastop) -- Write, Read, or
+           0 if either is legal next. */
+
+        var modestr = null;
+        switch (fmode) {
+            case filemode_Write:
+                modestr = "w";
+                break;
+            case filemode_Read:
+                modestr = "r";
+                break;
+            case filemode_ReadWrite:
+                modestr = "r+";
+                break;
+            case filemode_WriteAppend:
+                /* Can't use "a" here, because then fseek wouldn't work.
+                   Instead we use "r+" and then fseek to the end. */
+                modestr = "r+";
+                break;
+        }
+
+        try {
+            fstream.fd = fs.openSync(fstream.filename, modestr);
+        }
+        catch (ex) {
+            this.log('file_fopen: failed to open ' + fstream.filename + ': ' + ex);
+            return null;
+        }
+
+        if (fmode == filemode_WriteAppend) {
+            /* We must jump to the end of the file. */
+            try {
+                var stats = fs.fstatSync(fstream.fd);
+                fstream.mark = stats.size;
+            }
+            catch (ex) {}
+        }
+
+        return fstream;
+    }
+
+    /* Dialog.file_ref_exists(ref) -- returns whether the file exists
+     */
+    file_ref_exists(ref)
+    {
+        try {
+            fs.accessSync(ref.filename, fs.F_OK);
+            return true;
+        }
+        catch (ex) {
+            return false;
+        }
+    }
+
+    /* Dialog.file_remove_ref(ref) -- delete the file, if it exists
+     */
+    file_remove_ref(ref)
+    {
+        try {
+            fs.unlinkSync(ref.filename);
+        }
+        catch (ex) { }
+    }
+
+    /* Dialog.file_read(dirent, israw) -- read data from the file
+     *
+     * This call is intended for the non-streaming API, so it does not
+     * exist in this version of Dialog.
+     */
+    file_read(dirent, israw)
+    {
+        throw new Error('file_read not implemented in electrofs');
+    }
+
+    /* Dialog.file_write(dirent, content, israw) -- write data to the file
+     *
+     * This call is intended for the non-streaming API, so it does not
+     * exist in this version of Dialog.
+     */
+    file_write(dirent, content, israw)
+    {
+        throw new Error('file_write not implemented in electrofs');
+    }
+
+    /* Construct a file-filter list for a given usage type. These lists are
+       used by showOpenDialog and showSaveDialog, below. 
     */
-
-    var pathj = path_mod.join(gamedirpath, 'autosave.json');
-    var pathr = path_mod.join(gamedirpath, 'autosave.ram');
-
-    if (!snapshot) {
-        try {
-            fs.unlinkSync(pathj);
+    filters_for_usage(val)
+    {
+        switch (val) {
+        case 'data': 
+            return [ { name: 'Glk Data File', extensions: ['glkdata'] } ];
+        case 'save': 
+            return [ { name: 'Glk Save File', extensions: ['glksave'] } ];
+        case 'transcript': 
+            return [ { name: 'Transcript File', extensions: ['txt'] } ];
+        case 'command': 
+            return [ { name: 'Command File', extensions: ['txt'] } ];
+        default:
+            return [];
         }
-        catch (ex) {};
-        try {
-            fs.unlinkSync(pathr);
-        }
-        catch (ex) {};
-        return;
     }
 
-    /* Pull snapshot.ram out, if it exists. (It's okay to munge the
-       snapshot object,the caller doesn't want it back.) */
-    var ram = snapshot.ram;
-    snapshot.ram = undefined;
+    get_temp_path() {
+        return os.tmpdir();
+    }
 
-    var str = JSON.stringify(snapshot);
-    fs.writeFileSync(pathj, str, { encoding:'utf8' });
+    get_user_path() {
+        throw new Error('Method not implemented');
+    }
 
-    if (ram) {
-        var buf = new buffer_mod.Buffer(ram);
-        fs.writeFileSync(pathr, buf);
+    log(message) {
+        console.log(message);
+    }
+
+    open() {
+        throw new Error('Method not implemented');
     }
 }
 
-/* Load a snapshot (a JSONable object) from a signature-dependent location.
-*/
-function autosave_read(signature)
-{
-    var gamedirpath = path_mod.join(userpath, 'games', signature);
-    var pathj = path_mod.join(gamedirpath, 'autosave.json');
-    var pathr = path_mod.join(gamedirpath, 'autosave.ram');
-
-    try {
-        var str = fs.readFileSync(pathj, { encoding:'utf8' });
-        var snapshot = JSON.parse(str);
-
-        try {
-            var buf = fs.readFileSync(pathr, { encoding:null });
-            var ram = Array.from(buf.values());
-            snapshot.ram = ram;
-        }
-        catch (ex) {};
-
-        return snapshot;
+class ElectronDialog extends Dialog {
+    get_temp_path() {
+        return require('electron').remote.app.getPath('temp');
     }
-    catch (ex) {
-        return null;
-    };
+
+    get_user_path() {
+        return require('electron').remote.app.getPath('userData');
+    }
+
+    log(message) {
+        GlkOte.log(message);
+    }
+
+    /* Dialog.open(tosave, usage, gameid, callback) -- open a file-choosing dialog
+     *
+     * The "tosave" flag should be true for a save dialog, false for a load
+     * dialog.
+     *
+     * The "usage" and "gameid" arguments are arbitrary strings which describe the
+     * file. These filter the list of files displayed; the dialog will only list
+     * files that match the arguments. Pass null to either argument (or both) to
+     * skip filtering.
+     *
+     * The "callback" should be a function. This will be called with a fileref
+     * argument (see below) when the user selects a file. If the user cancels the
+     * selection, the callback will be called with a null argument.
+    */
+    open(tosave, usage, gameid, callback)
+    {
+        const dialog = require('electron').remote.dialog;
+        var opts = {
+            filters: this.filters_for_usage(usage)
+        };
+        var mainwin = require('electron').remote.getCurrentWindow();
+        if (!tosave) {
+            opts.properties = ['openFile'];
+            dialog.showOpenDialog(mainwin, opts, function(ls) {
+                    if (!ls || !ls.length) {
+                        callback(null);
+                    }
+                    else {
+                        var ref = { filename:ls[0], usage:usage };
+                        callback(ref);
+                    }
+                });
+        }
+        else {
+            dialog.showSaveDialog(mainwin, opts, function(path) {
+                    if (!path) {
+                        callback(null);
+                    }
+                    else {
+                        var ref = { filename:path, usage:usage };
+                        callback(ref);
+                    }
+                });
+        }
+    }
 }
 
-/* Dialog.file_write(dirent, content, israw) -- write data to the file
- *
- * This call is intended for the non-streaming API, so it does not
- * exist in this version of Dialog.
- */
-function file_write(dirent, content, israw)
-{
-    throw new Error('file_write not implemented in electrofs');
-}
-
-/* Dialog.file_read(dirent, israw) -- read data from the file
- *
- * This call is intended for the non-streaming API, so it does not
- * exist in this version of Dialog.
- */
-function file_read(dirent, israw)
-{
-    throw new Error('file_read not implemented in electrofs');
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.Dialog = Dialog;
+    module.exports.ElectronDialog = ElectronDialog;
 }
 
 /* End of Dialog namespace function. Return the object which will
    become the Dialog global. */
-return {
-    streaming: true,
-    open: dialog_open,
-
-    file_clean_fixed_name: file_clean_fixed_name,
-    file_construct_ref: file_construct_ref,
-    file_construct_temp_ref: file_construct_temp_ref,
-    file_ref_exists: file_ref_exists,
-    file_remove_ref: file_remove_ref,
-    file_fopen: file_fopen,
-
-    /* stubs for not-implemented functions */
-    file_write: file_write,
-    file_read: file_read,
-
-    /* support for the autosave hook */
-    autosave_write: autosave_write,
-    autosave_read: autosave_read
-};
+try {
+    return new ElectronDialog();
+}
+catch (e) {}
 
 }();
 

--- a/glkapi.js
+++ b/glkapi.js
@@ -45,6 +45,12 @@ Glk = function() {
 /* The VM interface object. */
 var VM = null;
 
+/* References to external libraries */
+var Dialog;
+var GiDispa;
+var GiLoad;
+var GlkOte;
+
 /* Environment capabilities. (Checked at init time.) */
 var has_canvas;
 
@@ -82,8 +88,43 @@ function init(vm_options) {
     /* Check for canvas support. We don't rely on jquery here. */
     has_canvas = (document.createElement('canvas').getContext != undefined);
 
+    /* Set references to external libraries */
+    if (vm_options.Dialog) {
+        Dialog = vm_options.Dialog;
+    }
+    else if (typeof window !== 'undefined' && window.Dialog) {
+        Dialog = window.Dialog;
+    }
+    else {
+        throw new Error('No reference to Dialog');
+    }
+
+    if (vm_options.GiDispa) {
+        GiDispa = vm_options.GiDispa;
+    }
+    else if (typeof window !== 'undefined' && window.GiDispa) {
+        GiDispa = window.GiDispa;
+    }
+
+    if (vm_options.GiLoad) {
+        GiLoad = vm_options.GiLoad;
+    }
+    else if (typeof window !== 'undefined' && window.GiLoad) {
+        GiLoad = window.GiLoad;
+    }
+
+    if (vm_options.GlkOte) {
+        GlkOte = vm_options.GlkOte;
+    }
+    else if (typeof window !== 'undefined' && window.GlkOte) {
+        GlkOte = window.GlkOte;
+    }
+    else {
+        throw new Error('No reference to GlkOte');
+    }
+
     VM = vm_options.vm;
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.set_vm(VM);
 
     vm_options.accept = accept_ui_event;
@@ -202,7 +243,7 @@ function handle_arrange_input() {
     gli_selectref.set_field(2, 0);
     gli_selectref.set_field(3, 0);
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.prepare_resume(gli_selectref);
     gli_selectref = null;
     VM.resume();
@@ -217,7 +258,7 @@ function handle_redraw_input() {
     gli_selectref.set_field(2, 0);
     gli_selectref.set_field(3, 0);
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.prepare_resume(gli_selectref);
     gli_selectref = null;
     VM.resume();
@@ -240,7 +281,7 @@ function handle_external_input(res) {
     gli_selectref.set_field(2, val1);
     gli_selectref.set_field(3, val2);
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.prepare_resume(gli_selectref);
     gli_selectref = null;
     VM.resume();
@@ -265,7 +306,7 @@ function handle_hyperlink_input(disprock, val) {
 
     win.hyperlink_request = false;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.prepare_resume(gli_selectref);
     gli_selectref = null;
     VM.resume();
@@ -290,7 +331,7 @@ function handle_mouse_input(disprock, xpos, ypos) {
 
     win.mouse_request = false;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.prepare_resume(gli_selectref);
     gli_selectref = null;
     VM.resume();
@@ -330,7 +371,7 @@ function handle_char_input(disprock, input) {
     win.char_request_uni = false;
     win.input_generation = null;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.prepare_resume(gli_selectref);
     gli_selectref = null;
     VM.resume();
@@ -377,7 +418,7 @@ function handle_line_input(disprock, input, termkey) {
     gli_selectref.set_field(2, input.length);
     gli_selectref.set_field(3, termcode);
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.unretain_array(win.linebuf);
     win.line_request = false;
     win.line_request_uni = false;
@@ -385,7 +426,7 @@ function handle_line_input(disprock, input, termkey) {
     win.input_generation = null;
     win.linebuf = null;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.prepare_resume(gli_selectref);
     gli_selectref = null;
     VM.resume();
@@ -2631,10 +2672,8 @@ function UniArrayToBE32(arr) {
    up in Safari, in Opera, and in Firefox if you have Firebug installed.)
 */
 function qlog(msg) {
-    if (window.console && console.log)
+    if (typeof console !== 'undefined' && console.log)
         console.log(msg);
-    else if (window.opera && opera.postError)
-        opera.postError(msg);
 }
 
 /* RefBox: Simple class used for "call-by-reference" Glk arguments. The object
@@ -2764,7 +2803,7 @@ function gli_new_window(type, rock) {
     if (win.next)
         win.next.prev = win;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.class_register('window', win);
     else
         win.disprock = gli_api_display_rocks++;
@@ -2778,7 +2817,7 @@ function gli_new_window(type, rock) {
 function gli_delete_window(win) {
     var prev, next;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.class_unregister('window', win);
     geometry_changed = true;
     
@@ -2998,7 +3037,7 @@ function gli_window_close(win, recurse) {
         }
     }
 
-    if (window.GiDispa && win.linebuf) {
+    if (GiDispa && win.linebuf) {
         GiDispa.unretain_array(win.linebuf);
         win.linebuf = null;
     }
@@ -3232,7 +3271,7 @@ function gli_new_stream(type, readable, writable, rock) {
     if (str.next)
         str.next.prev = str;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.class_register('stream', str);
 
     return str;
@@ -3248,7 +3287,7 @@ function gli_delete_stream(str) {
     gli_windows_unechostream(str);
 
     if (str.type == strtype_Memory) {
-        if (window.GiDispa)
+        if (GiDispa)
             GiDispa.unretain_array(str.buf);
     }
     else if (str.type == strtype_File) {
@@ -3258,7 +3297,7 @@ function gli_delete_stream(str) {
         }
     }
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.class_unregister('stream', str);
 
     prev = str.prev;
@@ -3356,7 +3395,7 @@ function gli_new_fileref(filename, usage, rock, ref) {
     if (fref.next)
         fref.next.prev = fref;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.class_register('fileref', fref);
 
     return fref;
@@ -3365,7 +3404,7 @@ function gli_new_fileref(filename, usage, rock, ref) {
 function gli_delete_fileref(fref) {
     var prev, next;
     
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.class_unregister('fileref', fref);
 
     prev = fref.prev;
@@ -4724,7 +4763,7 @@ function glk_stream_open_memory(buf, fmode, rock) {
             str.bufeof = 0;
         else
             str.bufeof = str.buflen;
-        if (window.GiDispa)
+        if (GiDispa)
             GiDispa.retain_array(buf);
     }
 
@@ -4734,7 +4773,7 @@ function glk_stream_open_memory(buf, fmode, rock) {
 function glk_stream_open_resource(filenum, rock) {
     var str;
 
-    if (!window.GiLoad || !GiLoad.find_data_chunk)
+    if (!GiLoad || !GiLoad.find_data_chunk)
         return null;
     var el = GiLoad.find_data_chunk(filenum);
     if (!el)
@@ -4773,7 +4812,7 @@ function glk_stream_open_resource(filenum, rock) {
 function glk_stream_open_resource_uni(filenum, rock) {
     var str;
 
-    if (!window.GiLoad || !GiLoad.find_data_chunk)
+    if (!GiLoad || !GiLoad.find_data_chunk)
         return null;
     var el = GiLoad.find_data_chunk(filenum);
     if (!el)
@@ -4962,7 +5001,7 @@ function gli_fileref_create_by_prompt_callback(obj) {
     ui_specialinput = null;
     ui_specialcallback = null;
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.prepare_resume(fref);
     VM.resume();
 }
@@ -5151,7 +5190,7 @@ function glk_request_line_event(win, buf, initlen) {
             win.request_echo_line_input = true;
         win.input_generation = event_generation;
         win.linebuf = buf;
-        if (window.GiDispa)
+        if (GiDispa)
             GiDispa.retain_array(buf);
     }
     else {
@@ -5207,7 +5246,7 @@ function glk_cancel_line_event(win, eventref) {
         eventref.set_field(3, 0);
     }
 
-    if (window.GiDispa)
+    if (GiDispa)
         GiDispa.unretain_array(win.linebuf);
     win.line_request = false;
     win.line_request_uni = false;
@@ -5303,7 +5342,7 @@ function glk_request_timer_events(msec) {
 /* Graphics functions. */
 
 function glk_image_get_info(imgid, widthref, heightref) {
-    if (!window.GiLoad || !GiLoad.get_image_info)
+    if (!GiLoad || !GiLoad.get_image_info)
         return null;
 
     var info = GiLoad.get_image_info(imgid);
@@ -5325,7 +5364,7 @@ function glk_image_draw(win, imgid, val1, val2) {
     if (!win)
         throw('glk_image_draw: invalid window');
 
-    if (!window.GiLoad || !GiLoad.get_image_info)
+    if (!GiLoad || !GiLoad.get_image_info)
         return 0;
     var info = GiLoad.get_image_info(imgid);
     if (!info)
@@ -5375,7 +5414,7 @@ function glk_image_draw_scaled(win, imgid, val1, val2, width, height) {
     if (!win)
         throw('glk_image_draw_scaled: invalid window');
 
-    if (!window.GiLoad || !GiLoad.get_image_info)
+    if (!GiLoad || !GiLoad.get_image_info)
         return 0;
     var info = GiLoad.get_image_info(imgid);
     if (!info)
@@ -5980,7 +6019,7 @@ function glk_stream_open_memory_uni(buf, fmode, rock) {
             str.bufeof = 0;
         else
             str.bufeof = str.buflen;
-        if (window.GiDispa)
+        if (GiDispa)
             GiDispa.retain_array(buf);
     }
 
@@ -6028,7 +6067,7 @@ function glk_request_line_event_uni(win, buf, initlen) {
             win.request_echo_line_input = true;
         win.input_generation = event_generation;
         win.linebuf = buf;
-        if (window.GiDispa)
+        if (GiDispa)
             GiDispa.retain_array(buf);
     }
     else {

--- a/glkapi.js
+++ b/glkapi.js
@@ -431,8 +431,8 @@ function handle_line_input(disprock, input, termkey) {
     VM.resume();
 }
 
-function update() {
-    var dataobj = { type: 'update', gen: event_generation };
+function update(type) {
+    var dataobj = { type: type || 'update', gen: event_generation };
     var winarray = null;
     var contentarray = null;
     var inputarray = null;
@@ -4054,7 +4054,7 @@ function glk_exit() {
     gli_selectref = null;
     if (option_exit_warning)
         GlkOte.warning(option_exit_warning);
-    GlkOte.update({ type: 'exit' });
+    update('exit');
     return DidNotReturn;
 }
 

--- a/glkapi.js
+++ b/glkapi.js
@@ -51,8 +51,8 @@ var GiDispa;
 var GiLoad;
 var GlkOte;
 
-/* Environment capabilities. (Checked at init time.) */
-var has_canvas;
+/* Environment capabilities */
+var support = {};
 
 /* Options from the vm_options object. */
 var option_exit_warning;
@@ -85,9 +85,6 @@ var current_partial_outputs = null;
    library sets that up for you.)
 */
 function init(vm_options) {
-    /* Check for canvas support. We don't rely on jquery here. */
-    has_canvas = (document.createElement('canvas').getContext != undefined);
-
     /* Set references to external libraries */
     if (vm_options.Dialog) {
         Dialog = vm_options.Dialog;
@@ -166,8 +163,10 @@ function accept_ui_event(obj) {
     switch (obj.type) {
     case 'init':
         content_metrics = obj.metrics;
-        /* We ignore the support array. This library is updated in sync
-           with GlkOte, so we know what it supports. */
+        /* Process the support array */
+        if (obj.support) {
+            obj.support.forEach(function(item) {support[item] = 1;});
+        }
         VM.init();
         break;
 
@@ -4111,22 +4110,20 @@ function glk_gestalt_ext(sel, val, arr) {
         return 2; // gestalt_CharOutput_ExactPrint
 
     case 4: // gestalt_MouseInput
-        if (val == Const.wintype_TextBuffer)
+        if (val == Const.wintype_TextGrid)
             return 1;
-        if (val == Const.wintype_Graphics && has_canvas)
+        if (support.graphics && val == Const.wintype_Graphics)
             return 1;
         return 0;
 
     case 5: // gestalt_Timer
-        return 1;
+        return support.timer || 0;
 
     case 6: // gestalt_Graphics
-        return 1;
+        return support.graphics || 0;
 
     case 7: // gestalt_DrawImage
-        if (val == Const.wintype_TextBuffer)
-            return 1;
-        if (val == Const.wintype_Graphics && has_canvas)
+        if (support.graphics && (val == Const.wintype_TextBuffer || val == Const.wintype_Graphics))
             return 1;
         return 0;
 
@@ -4140,10 +4137,10 @@ function glk_gestalt_ext(sel, val, arr) {
         return 0;
 
     case 11: // gestalt_Hyperlinks
-        return 1;
+        return support.hyperlinks || 0;
 
     case 12: // gestalt_HyperlinkInput
-        if (val == 3 || val == 4) // TextBuffer or TextGrid
+        if (support.hyperlinks && (val == Const.wintype_TextBuffer || val == Const.wintype_TextGrid))
             return 1;
         else
             return 0;
@@ -4152,7 +4149,7 @@ function glk_gestalt_ext(sel, val, arr) {
         return 0;
 
     case 14: // gestalt_GraphicsTransparency
-        return 1;
+        return support.graphics || 0;
 
     case 15: // gestalt_Unicode
         return 1;
@@ -4291,7 +4288,7 @@ function glk_window_open(splitwin, method, size, wintype, rock) {
         newwin.cursory = 0;
         break;
     case Const.wintype_Graphics:
-        if (!has_canvas) {
+        if (!support.graphics) {
             /* Graphics windows not supported; silently return null */
             gli_delete_window(newwin);
             return null;

--- a/glkapi.js
+++ b/glkapi.js
@@ -4054,6 +4054,7 @@ function glk_exit() {
     gli_selectref = null;
     if (option_exit_warning)
         GlkOte.warning(option_exit_warning);
+    GlkOte.update({ type: 'exit' });
     return DidNotReturn;
 }
 
@@ -6211,7 +6212,7 @@ function glk_date_to_simple_time_local(dateref, factor) {
 
 /* End of Glk namespace function. Return the object which will
    become the Glk global. */
-return {
+var api = {
     version: '2.2.3', /* GlkOte/GlkApi version */
     init : init,
     update : update,
@@ -6353,6 +6354,12 @@ return {
     glk_stream_open_resource : glk_stream_open_resource,
     glk_stream_open_resource_uni : glk_stream_open_resource_uni
 };
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+}
+
+return api;
 
 }();
 


### PR DESCRIPTION
Here are some conservative changes which allow glkapi.js to be used in node.

Notes:

- Supports the external libraries being loaded either from vm_options or from the window object if it exists. Throws if Dialog or GlkOte are not loaded. Allows GiDispa and GiLoad to not be loaded.
- But I just noticed that restore_allstate has a reference to GiLoad without checking whether it is set. So probably that one should become required too? There are also many references to GiDispa in the autosaving code... we'll probably need to have a longer discussion on whether and how glkapi.js can/should be used outside of GlkOte and Quixe. I'll maintain a fork if I have to, but I'd really love to be able to just copy over the file everytime there's an update to GlkOte. (Depending on GiDispa may make perfect sense and when I add autosaving to ZVM I may discover that I want to use it too, so maybe all that will be needed is one guard checking for GiDispa at the beginning of the autosaving functions.)
- Uses the support array in glk_gestalt. I removed the has_canvas check, and it now relies on graphics being listed in the support array.
- Fixes a bug: gestalt_MouseInput was checking wintype_TextBuffer instead of wintype_TextGrid
- glk_exit sends an exit message to GlkOte. I needed this to stop listening for events in glkote-term. Possibly should also send an exit message in fatal_warning?
- Supports CommonJS
- Does not have my changes to glk_fileref_create_by_prompt