### PR TITLE
Add an input placeholder "Tap here to type" on touchscreen devices

### DIFF
--- a/glkote.css
+++ b/glkote.css
@@ -148,6 +148,11 @@
   font-size: 14px;
 }
 
+input:focus::placeholder {
+  /* Hide "Tap here to type" placeholder when the input is focused */
+  color: transparent;
+}
+
 /* The following are used for image alignment (in buffer windows). */
 
 .ImageMarginLeft {

--- a/glkote.js
+++ b/glkote.js
@@ -1500,6 +1500,9 @@ function accept_inputset(arg) {
       inputel = $('<input>',
         { id: dom_prefix+'win'+win.id+'_input',
           'class': classes, type: 'text', maxlength: maxlen });
+      if ('ontouchstart' in window) {
+        inputel.attr('placeholder', 'Tap here to type');
+      }
       if (true) /* should be mobile-webkit-only? */
         inputel.attr('autocapitalize', 'off');
       inputel.attr({


### PR DESCRIPTION
Fixes #49 

On touchscreen devices, if you blur focus from the primary input, it can be hard to figure out how to bring the keyboard back up. ("What's that > thing?")

So, on touchscreen devices, we'll add input placeholder text, "Tap here to type" and use CSS to hide that placeholder text if the input is currently focused.
![Simulator Screen Shot - iPod touch (7th generation) - 2021-11-23 at 19 45 19](https://user-images.githubusercontent.com/96150/143171302-a15b3b67-9a27-4961-a785-7b98c0eb794d.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2021-11-23 at 19 45 26](https://user-images.githubusercontent.com/96150/143171304-0d5ce222-9641-475e-833a-89d0cd156b56.png)

