### PR TITLE
Allow mobile users to tap the prompt line to focus the input box

### DIFF
--- a/glkote.js
+++ b/glkote.js
@@ -1376,10 +1376,9 @@ function accept_one_content(arg) {
            buffermarginx is one pixel too low. We fudge for that, giving a
            result which errs on the low side. */
         var width = win.frameel.width() - (current_metrics.buffermarginx + pos.left + 2);
-        if (width < 1)
-          width = 1;
-        inputel.css({ position: 'absolute',
-          left: '0px', top: '0px', width: width+'px' });
+        if (width < 200)
+          width = 200;
+        inputel.css({ width: width+'px' });
         cursel.append(inputel);
       }
 
@@ -1566,10 +1565,9 @@ function accept_inputset(arg) {
            buffermarginx is one pixel too low. We fudge for that, giving a
            result which errs on the low side. */
       var width = win.frameel.width() - (current_metrics.buffermarginx + pos.left + 2);
-      if (width < 1)
-        width = 1;
-      inputel.css({ position: 'absolute',
-        left: '0px', top: '0px', width: width+'px' });
+      if (width < 200)
+        width = 200;
+      inputel.css({ width: width+'px' });
       if (newinputel)
         cursel.append(inputel);
     }

--- a/glkote.js
+++ b/glkote.js
@@ -1364,6 +1364,7 @@ function accept_one_content(arg) {
       var cursel = $('<span>',
         { id: dom_prefix+'win'+win.id+'_cursor', 'class': 'InvisibleCursor' } );
       divel.append(cursel);
+      divel.click(function () { if (win.inputel) win.inputel.focus(); });
 
       if (win.inputel) {
         /* Put back the inputel that we found earlier. */


### PR DESCRIPTION
Fixes #53

I guess strictly speaking it doesn't perfectly fix #53, because there's still no easy way for users to realize that they need to tap on that line to type, even with my PR #51, because the hint won't be visible. But at least it will be _possible_ to open the keyboard, if you can guess to click on the last line, which is way better than what we have now.

(If we cared about this, we could add some special styling to the input line, e.g. turn it blue or something…?)