### PR TITLE
Support character input in Android Chrome (fixes #7)

### DIFF
--- a/glkote.js
+++ b/glkote.js
@@ -1490,6 +1490,7 @@ function accept_inputset(arg) {
             else if (argi.type == 'char') {
                 inputel.on('keypress', evhan_input_char_keypress);
                 inputel.on('keydown', evhan_input_char_keydown);
+                inputel.on('input', evhan_input_char_input);
             }
             inputel.on('focus', win.id, evhan_input_focus);
             //inputel.on('blur', win.id, evhan_input_blur); // Currently has no effect
@@ -2759,6 +2760,32 @@ function evhan_input_char_keypress(ev) {
 
     send_response('char', win, res);
     return false;
+}
+
+/* Event handler: input events on input fields (character input)
+   The keydown and keypress inputs are unreliable in mobile browsers with
+   virtual keyboards. This handler can handle character input for printable
+   characters, but not function/arrow keys.
+*/
+function evhan_input_char_input(ev) {
+  const char = ev.target.value[0]
+  if (char === '') {
+    return false;
+  }
+  var winid = $(this).data('winid');
+  var win = windowdic[winid];
+  if (!win || !win.input) {
+    return true;
+  }
+  ev.target.value = ''
+  send_response('char', win, char);
+  /* Even though we have emptied the input, Android acts as though it still has
+     spaces within it, and won't send backspace keydown events until the phantom
+     spaces have all been deleted. Refocusing seems to fix it. */
+  if (char === ' ') {
+    $(ev.target).trigger('blur').trigger('focus')
+  }
+  return false;
 }
 
 /* Event handler: keydown events on input fields (line input)


### PR DESCRIPTION
Finally worked out how to support character input in Android Chrome. Basically we attach a listener for the `input` event, and then take the first character of the input for the event. Fixes https://github.com/erkyrath/glkote/issues/7