### PR TITLE
Blorb typo?

### DIFF
--- a/gi_blorb.js
+++ b/gi_blorb.js
@@ -543,7 +543,7 @@ function get_data_chunk(val) {
     if (!chunk)
         return null;
 
-    return { data:chunk.content, type:chunk.type, binary:chunk.binary };
+    return { data:chunk.content, type:chunk.blorbtype, binary:chunk.binary };
 }
 
 /* Convert an array of numeric byte values into a base64 string. */


### PR DESCRIPTION
Just looking at the code, I haven't run it, but isn't the `type` setting only defined for pictures? I assume this should be `blorbtype` instead.