### PR TITLE
Don't ignore user input events

### DIFF
--- a/glkote.js
+++ b/glkote.js
@@ -2086,7 +2086,12 @@ function send_response(type, win, val, val2) {
 
     if (generation <= generation_sent
         && !(type == 'init' || type == 'refresh')) {
-        glkote_log('Not sending repeated generation number: ' + generation);
+        if (type == 'char' || type == 'line' || type == 'hyperlink' || type == 'mouse') {
+            glkote_log('Scheduling event for the next generation: ' + type);
+            defer_func(() => send_response(type, win, val, val2));
+        } else {
+            glkote_log('Not sending repeated generation number: ' + generation);
+        }
         return;
     }
 


### PR DESCRIPTION
Currently timer events might interfere with the user input events. With this fix user events are not lost.